### PR TITLE
By using mutation instead of assignment, avoid shadowing.

### DIFF
--- a/test_optional.py
+++ b/test_optional.py
@@ -41,43 +41,41 @@ class TestOptional(unittest.TestCase):
         self.assertEqual("thing", optional.get())
 
     def test_will_run_consumer_if_present(self):
-        seen = False
+        scope = {'seen': False}
 
         def some_thing_consumer(thing):
-            nonlocal seen
-            seen = True
+            scope['seen'] = True
 
         optional = Optional.of("thing")
         optional.if_present(some_thing_consumer)
-        self.assertTrue(seen)
+        self.assertTrue(scope['seen'])
 
     def test_will_not_run_consumer_if_not_present(self):
-        seen = False
+        scope = {'seen': False}
 
         def some_thing_consumer(thing):
-            nonlocal seen
-            seen = True
+            scope['seen'] = True
 
         optional = Optional.empty()
         optional.if_present(some_thing_consumer)
-        self.assertFalse(seen)
+        self.assertFalse(scope['seen'])
 
     def test_will_run_or_else_from_if_present_when_not_present(self):
-        if_seen = False
-        else_seen = False
+        scope = {
+            'if_seen': False,
+            'else_seen': False
+        }
 
         def some_thing_consumer(thing):
-            nonlocal if_seen
-            if_seen = True
+            scope['if_seen'] = True
 
         def or_else_procedure():
-            nonlocal else_seen
-            else_seen = True
+            scope['else_seen'] = True
 
         optional = Optional.empty()
         optional.if_present(some_thing_consumer).or_else(or_else_procedure)
-        self.assertFalse(if_seen)
-        self.assertTrue(else_seen)
+        self.assertFalse(scope['if_seen'])
+        self.assertTrue(scope['else_seen'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- This works in Python2 and 3.